### PR TITLE
Fix typo

### DIFF
--- a/www/class/centreonPurgeEngine.class.php
+++ b/www/class/centreonPurgeEngine.class.php
@@ -200,7 +200,7 @@ class CentreonPurgeEngine
         foreach ($this->tablesToPurge[$table]['partitions'] as $partName => $partTimestamp) {
             if ($partTimestamp < $this->tablesToPurge[$table]['retention']) {
                 $dropPartitions[] = '`' . $partName . '`';
-                echo "[" . date(DATE_RFC822) . "] Partition will be delete " . $partName . "\n";
+                echo "[" . date(DATE_RFC822) . "] Partition will be deleted " . $partName . "\n";
             }
         }
 


### PR DESCRIPTION
Fix typo, but still leave the word untouched to be detected by grep. I was considering changint the wording to "Partition will be purged" but that will not be picked up by monitoring tools based on grep.